### PR TITLE
feat: auto-update release PR after bun.lock sync

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -173,7 +173,8 @@
       "WebFetch(domain:docs.npmjs.com)",
       "Bash(git remote set-url:*)",
       "Bash(./packages/cli/dist/cli.js -t \"Fix #6\" --issue-status open)",
-      "Bash(issue-linker:*)"
+      "Bash(issue-linker:*)",
+      "Bash(git --no-pager log -1 --pretty=%s)"
     ],
     "deny": []
   },

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -171,7 +171,9 @@
       "WebSearch",
       "Bash(git revert:*)",
       "WebFetch(domain:docs.npmjs.com)",
-      "Bash(git remote set-url:*)"
+      "Bash(git remote set-url:*)",
+      "Bash(./packages/cli/dist/cli.js -t \"Fix #6\" --issue-status open)",
+      "Bash(issue-linker:*)"
     ],
     "deny": []
   },

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -162,33 +162,11 @@
       "Bash(git remote get-url:*)",
       "Bash(biome:*)",
       "Bash(time bun run:*)",
-      "Bash(do time bun run ./src/cli.ts --branch \"feat/issue-3-test\" --repo \"sugurutakahashi-1234/issue-number-branch\")",
       "Bash(time bun test:*)",
-      "Bash(do echo \"=== Checking $scope ===\")",
       "Bash(git ls-tree:*)",
-      "Bash(GITHUB_TOKEN=\"\" GH_TOKEN=\"\" bun run src/cli.ts --text \"Fix #123\" --repo \"owner/repo\")",
-      "Bash(DEBUG_TOKEN_SOURCE=1 GITHUB_TOKEN=\"\" GH_TOKEN=\"\" bun run src/cli.ts --text \"Fix #123\" --repo \"owner/repo\")",
-      "Bash(-e 's/result\\.issueNumbers/result.issues?.found/g' )",
-      "Bash(-e 's/result\\.validIssues/result.issues?.valid/g' )",
-      "Bash(-e 's/result\\.invalidIssues\\]/\\(result.issues?.notFound || []).concat(result.issues?.wrongState || [])\\]/g' )",
-      "Bash(-e 's/result\\.notFoundIssues/result.issues?.notFound/g' )",
-      "Bash(-e 's/result\\.wrongStateIssues/result.issues?.wrongState/g' )",
-      "Bash(-e 's/expect(result\\.excluded)\\.toBe(true)/expect(result.reason).toBe(\"\"excluded\"\")/g' )",
-      "Bash(-e 's/expect(result\\.excluded)\\.toBe(false)/expect(result.reason).not.toBe(\"\"excluded\"\")/g' )",
-      "Bash(-e 's/result\\.metadata\\.mode/result.input.mode/g' )",
-      "Bash(-e 's/result\\.metadata\\.repo/result.input.repo/g' )",
-      "Bash(src/application/check-message-use-case.test.ts)",
-      "Bash(-e 's/expect(result\\.invalidIssues)\\.toEqual(\\[\\([^]]*\\)\\])/expect([...(result.issues?.notFound || []), ...(result.issues?.wrongState || [])]).toEqual([\\1])/g' )",
-      "Bash(/Users/sugurutakahashi/git/issue-linker/packages/core/src/application/check-message-use-case.test.ts)",
-      "Bash(GITHUB_TOKEN=\"\" GH_TOKEN=\"\" bun run packages/cli/src/cli.ts --text \"[excluded] text\" --exclude \"\\[excluded\\]\")",
       "WebFetch(domain:cli.github.com)",
-      "Bash(GH_HOST=github.enterprise.com bun run packages/cli/src/cli.ts -t \"test-123\" --check-mode branch)",
       "Bash(false)",
-      "Bash(GITHUB_REPOSITORY=owner/repo bun run --filter '@issue-linker/action' test)",
-      "Bash(GITHUB_REPOSITORY=owner/repo bun run --filter '@issue-linker/action' test:quiet)",
       "Bash(git rebase:*)",
-      "Bash(GITHUB_TOKEN=\"\" GH_TOKEN=\"\" bun run packages/cli/src/cli.ts -t \"feat/issue-3-test\" --check-mode branch --repo \"sugurutakahashi-1234/issue-linker\")",
-      "Bash(GITHUB_TOKEN=\"\" GH_TOKEN=\"\" bun test --no-coverage)",
       "Bash(brew upgrade:*)",
       "WebSearch",
       "Bash(git revert:*)",
@@ -196,8 +174,5 @@
     ],
     "deny": []
   },
-  "enableAllProjectMcpServers": true,
-  "enabledMcpjsonServers": [
-    "playwright"
-  ]
+  "enableAllProjectMcpServers": true
 }

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -170,7 +170,8 @@
       "Bash(brew upgrade:*)",
       "WebSearch",
       "Bash(git revert:*)",
-      "WebFetch(domain:docs.npmjs.com)"
+      "WebFetch(domain:docs.npmjs.com)",
+      "Bash(git remote set-url:*)"
     ],
     "deny": []
   },

--- a/.github/workflows/ci-sync-bun-lock-from-release-pr.yml
+++ b/.github/workflows/ci-sync-bun-lock-from-release-pr.yml
@@ -34,6 +34,7 @@ jobs:
           bun install
           
       - name: Commit and push if changed
+        id: commit
         run: |
           if ! git diff --quiet -- bun.lock; then
             git config user.name "github-actions[bot]"
@@ -41,6 +42,17 @@ jobs:
             git add bun.lock
             git commit -m "chore: sync bun.lock with version bump"
             git push
+            echo "bun_lock_updated=true" >> $GITHUB_OUTPUT
           else
             echo "No changes to bun.lock"
+            echo "bun_lock_updated=false" >> $GITHUB_OUTPUT
           fi
+      
+      # Update release-please PR after bun.lock sync
+      - name: Update Release PR
+        if: steps.commit.outputs.bun_lock_updated == 'true'
+        uses: googleapis/release-please-action@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          config-file: release-please-config.json
+          manifest-file: .release-please-manifest.json

--- a/README.md
+++ b/README.md
@@ -45,16 +45,16 @@ Check if issue references actually exist in your repository:
 
 ```bash
 $ npx issue-linker -t "Fix #123"
-> ✅ Valid issues: #123
+# > ✅ Valid issues: #123 in owner/repo
 
 $ npx issue-linker -t "Add feature #999"
-> ❌ Issues not found: #999 in owner/repo
+# > ❌ Issues not found: #999 in owner/repo
 
 $ npx issue-linker -t "Implement #123" --issue-status closed
-> ❌ Wrong state: #123 in owner/repo
+# > ❌ Wrong state: #123 is open (expected: closed) in owner/repo
 
 $ npx issue-linker -t "feature/auth-improvements-123" -c branch
-> ✅ Valid issues: #123
+# > ✅ Valid issues: #123 in owner/repo
 ```
 
 ### More Examples

--- a/README.md
+++ b/README.md
@@ -44,16 +44,16 @@ npm install -g issue-linker
 Check if issue references actually exist in your repository:
 
 ```bash
-$ npx issue-linker -t "Fix #123"
+npx issue-linker -t "Fix #123"
 # > ✅ Valid issues: #123 in owner/repo
 
-$ npx issue-linker -t "Add feature #999"
+npx issue-linker -t "Add feature #999"
 # > ❌ Issues not found: #999 in owner/repo
 
-$ npx issue-linker -t "Implement #123" --issue-status closed
+npx issue-linker -t "Implement #123" --issue-status closed
 # > ❌ Wrong state: #123 is open (expected: closed) in owner/repo
 
-$ npx issue-linker -t "feature/auth-improvements-123" -c branch
+npx issue-linker -t "feature/auth-improvements-123" -c branch
 # > ✅ Valid issues: #123 in owner/repo
 ```
 
@@ -90,19 +90,19 @@ npx issue-linker -t "$(git log -1 --pretty=%s)" -c commit
 
 ```bash
 # Exclude WIP commits
-$ issue-linker -t "[WIP] Fix #789" --exclude "*[WIP]*"
+issue-linker -t "[WIP] Fix #789" --exclude "*[WIP]*"
 # > ⏭️ Skipped: Matched exclude pattern "*[WIP]*"
 
 # JSON output for CI/CD
-$ issue-linker -t "Fix #789" --json
-{
-  "success": true,
-  "message": "Valid issues: #789 in owner/repo",
-  ...
-}
+issue-linker -t "Fix #789" --json
+# > {
+# >   "success": true,
+# >   "message": "Valid issues: #789 in owner/repo",
+# >   ...
+# > }
 
 # GitHub Enterprise Server
-$ issue-linker -t "Fix #321" --hostname github.enterprise.com
+issue-linker -t "Fix #321" --hostname github.enterprise.com
 # > ✅ Valid issues: #321 in owner/repo
 ```
 
@@ -131,11 +131,11 @@ Skip validation by including `[skip issue-linker]` or `[issue-linker skip]` anyw
 
 ```bash
 # Skip auto-generated PR titles
-$ issue-linker -t "Release v2.0.0 [skip issue-linker]"
+issue-linker -t "Release v2.0.0 [skip issue-linker]"
 # > ⏭️ Skipped: Contains [skip issue-linker] marker
 
 # Skip dependency updates
-$ issue-linker -t "chore: update dependencies [issue-linker skip]" -c commit
+issue-linker -t "chore: update dependencies [issue-linker skip]" -c commit
 # > ⏭️ Skipped: Contains [issue-linker skip] marker
 ```
 

--- a/README.md
+++ b/README.md
@@ -41,13 +41,25 @@ npm install -g issue-linker
 
 ## Quick Start
 
+Check if issue references actually exist in your repository:
+
 ```bash
-# Validate text with issue reference
-npx issue-linker -t "Fix #123"
+$ npx issue-linker -t "Fix #123"
+> ✅ Valid issues: #123
 
-# Check only open issues
-npx issue-linker -t "Fix #123" --issue-status open
+$ npx issue-linker -t "Add feature #999"
+> ❌ Issues not found: #999 in owner/repo
 
+$ npx issue-linker -t "Implement #123" --issue-status closed
+> ❌ Wrong state: #123 in owner/repo
+
+$ npx issue-linker -t "feature/auth-improvements-123" -c branch
+> ✅ Valid issues: #123
+```
+
+### More Examples
+
+```bash
 # Validate your current branch name
 npx issue-linker -t "$(git branch --show-current)" -c branch
 

--- a/README.md
+++ b/README.md
@@ -90,13 +90,20 @@ npx issue-linker -t "$(git log -1 --pretty=%s)" -c commit
 
 ```bash
 # Exclude WIP commits
-issue-linker -t "[WIP] Fix #789" --exclude "*[WIP]*"
+$ issue-linker -t "[WIP] Fix #789" --exclude "*[WIP]*"
+# > ⏭️ Skipped: Matched exclude pattern "*[WIP]*"
 
 # JSON output for CI/CD
-issue-linker -t "Fix #789" --json
+$ issue-linker -t "Fix #789" --json
+{
+  "success": true,
+  "message": "Valid issues: #789 in owner/repo",
+  ...
+}
 
 # GitHub Enterprise Server
-issue-linker -t "Fix #321" --hostname github.enterprise.com
+$ issue-linker -t "Fix #321" --hostname github.enterprise.com
+# > ✅ Valid issues: #321 in owner/repo
 ```
 
 ## Check Modes
@@ -124,10 +131,12 @@ Skip validation by including `[skip issue-linker]` or `[issue-linker skip]` anyw
 
 ```bash
 # Skip auto-generated PR titles
-issue-linker -t "Release v2.0.0 [skip issue-linker]"
+$ issue-linker -t "Release v2.0.0 [skip issue-linker]"
+# > ⏭️ Skipped: Contains [skip issue-linker] marker
 
 # Skip dependency updates
-issue-linker -t "chore: update dependencies [skip issue-linker]" -c commit
+$ issue-linker -t "chore: update dependencies [issue-linker skip]" -c commit
+# > ⏭️ Skipped: Contains [issue-linker skip] marker
 ```
 
 ## GitHub Actions
@@ -257,10 +266,10 @@ npx issue-linker -t "$message" -c commit || {
 issue-linker -t "$(git branch --show-current)" -c branch
 
 # Validate last commit
-issue-linker -t "$(git --no-pager log -1 --pretty=%s)" -c commit
+issue-linker -t "$(git log -1 --pretty=%s)" -c commit
 
 # Validate all commits in a PR
-git --no-pager log main..HEAD --pretty=%s | while read commit_message; do
+git log main..HEAD --pretty=%s | while read commit_message; do
   issue-linker -t "$commit_message" -c commit
 done
 ```

--- a/packages/action/src/index.ts
+++ b/packages/action/src/index.ts
@@ -236,36 +236,10 @@ async function run() {
       const prefix = results.length > 1 ? `[${actionMode}] ` : "";
 
       if (result.success) {
-        // Success cases
-        switch (result.reason) {
-          case "excluded":
-            core.info(`${prefix}Text was excluded from validation`);
-            break;
-          case "skipped":
-            core.info(`${prefix}Validation skipped due to skip marker`);
-            break;
-          case "valid":
-            if (result.issues?.valid && result.issues.valid.length > 0) {
-              core.info(
-                `${prefix}Valid issues: #${result.issues.valid.join(", #")}`,
-              );
-            } else {
-              core.info(`${prefix}${result.message}`);
-            }
-            break;
-          case "no-issues":
-          case "invalid-issues":
-          case "error":
-            core.info(`${prefix}${result.message}`);
-            break;
-          default: {
-            // Exhaustive check: TypeScript will error if a new reason is added
-            const _exhaustive: never = result.reason;
-            throw new Error(`Unexpected reason: ${_exhaustive}`);
-          }
-        }
+        // Success cases - simply use the message from result-factory
+        core.info(`${prefix}${result.message}`);
       } else {
-        // Failure cases
+        // Failure cases - simply use the message from result-factory
         core.error(`${prefix}${result.message}`);
 
         // Show details for failed validations
@@ -276,9 +250,10 @@ async function run() {
             details.push(`Not found: #${result.issues.notFound.join(", #")}`);
           }
           if (result.issues.wrongState.length > 0) {
-            details.push(
-              `Wrong state: #${result.issues.wrongState.join(", #")}`,
+            const wrongStateMessages = result.issues.wrongState.map(
+              (issue) => `#${issue.number} is ${issue.actualState}`,
             );
+            details.push(`Wrong state: ${wrongStateMessages.join(", ")}`);
           }
 
           if (details.length > 0) {

--- a/packages/cli/src/cli.test.ts
+++ b/packages/cli/src/cli.test.ts
@@ -50,7 +50,7 @@ describe("CLI", () => {
       const text = await new Response(proc.stdout).text();
       await proc.exited;
 
-      expect(text).toContain("excluded from validation");
+      expect(text).toContain("Skipped: Matched exclude pattern");
       expect(proc.exitCode).toBe(0);
     });
 
@@ -65,7 +65,7 @@ describe("CLI", () => {
       const text = await new Response(proc.stdout).text();
       await proc.exited;
 
-      expect(text).toContain("excluded from validation");
+      expect(text).toContain("Skipped: Matched exclude pattern");
       expect(proc.exitCode).toBe(0);
     });
 
@@ -90,7 +90,7 @@ describe("CLI", () => {
       const text = await new Response(proc.stdout).text();
       await proc.exited;
 
-      expect(text).toContain("excluded from validation");
+      expect(text).toContain("Skipped: Matched exclude pattern");
       expect(proc.exitCode).toBe(0);
     });
 
@@ -249,7 +249,7 @@ describe("CLI", () => {
       const text = await new Response(proc.stdout).text();
       await proc.exited;
 
-      expect(text).toContain("excluded");
+      expect(text).toContain("Skipped: Matched exclude pattern");
       expect(proc.exitCode).toBe(0);
     });
 

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -96,34 +96,8 @@ program
 
       // Display human-readable result
       if (result.success) {
-        // Success output
-        switch (result.reason) {
-          case "excluded":
-            console.log(`✅ Text was excluded from validation`);
-            break;
-          case "skipped":
-            console.log(`✅ Validation skipped due to skip marker`);
-            break;
-          case "valid":
-            if (result.issues?.valid && result.issues.valid.length > 0) {
-              console.log(
-                `✅ Valid issues: #${result.issues.valid.join(", #")}`,
-              );
-            } else {
-              console.log(`✅ ${result.message}`);
-            }
-            break;
-          case "no-issues":
-          case "invalid-issues":
-          case "error":
-            console.log(`✅ ${result.message}`);
-            break;
-          default: {
-            // Exhaustive check: TypeScript will error if a new reason is added
-            const _exhaustive: never = result.reason;
-            throw new Error(`Unexpected reason: ${_exhaustive}`);
-          }
-        }
+        // Success output - simply use the message from result-factory
+        console.log(`✅ ${result.message}`);
 
         // Show extra details in verbose mode
         if (options.verbose) {
@@ -136,7 +110,7 @@ program
         }
         process.exit(0);
       } else {
-        // Error output
+        // Error output - simply use the message from result-factory
         console.error(`❌ ${result.message}`);
 
         // Show details
@@ -150,13 +124,14 @@ program
             details.push(`Not found: #${result.issues.notFound.join(", #")}`);
           }
           if (result.issues.wrongState.length > 0) {
-            const stateInfo =
-              result.input.issueStatus === "all"
-                ? "Wrong state"
-                : `Wrong state (expected: ${result.input.issueStatus})`;
-            details.push(
-              `${stateInfo}: #${result.issues.wrongState.join(", #")}`,
-            );
+            const wrongStateMessages = result.issues.wrongState.map((issue) => {
+              const expected =
+                result.input.issueStatus === "all"
+                  ? ""
+                  : ` (expected: ${result.input.issueStatus})`;
+              return `#${issue.number} is ${issue.actualState}${expected}`;
+            });
+            details.push(`Wrong state: ${wrongStateMessages.join(", ")}`);
           }
 
           if (details.length > 0) {

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -96,8 +96,12 @@ program
 
       // Display human-readable result
       if (result.success) {
-        // Success output - simply use the message from result-factory
-        console.log(`✅ ${result.message}`);
+        // Success output - use appropriate emoji based on reason
+        const emoji =
+          result.reason === "excluded" || result.reason === "skipped"
+            ? "⏭️ "
+            : "✅";
+        console.log(`${emoji} ${result.message}`);
 
         // Show extra details in verbose mode
         if (options.verbose) {

--- a/packages/core/src/application/check-message-use-case.ts
+++ b/packages/core/src/application/check-message-use-case.ts
@@ -97,7 +97,10 @@ export async function checkMessage(
     const githubToken = validatedArgs.githubToken ?? getGitHubToken();
     const validIssues: number[] = [];
     const notFoundIssues: number[] = [];
-    const wrongStateIssues: number[] = [];
+    const wrongStateIssues: Array<{
+      number: number;
+      actualState: "open" | "closed";
+    }> = [];
 
     for (const issueNumber of issueNumbers) {
       const result = await getGitHubIssue(
@@ -114,7 +117,10 @@ export async function checkMessage(
         result.issue &&
         !isIssueStateAllowed(result.issue.state, issueStatus)
       ) {
-        wrongStateIssues.push(issueNumber);
+        wrongStateIssues.push({
+          number: issueNumber,
+          actualState: result.issue.state,
+        });
       } else if (result.issue) {
         validIssues.push(issueNumber);
       }

--- a/packages/core/src/domain/result-factory.ts
+++ b/packages/core/src/domain/result-factory.ts
@@ -52,7 +52,7 @@ export function createValidResult(
 ): CheckMessageResult {
   return {
     success: true,
-    message: `Valid issue(s) found: #${issues.valid.join(", #")} in ${input.repo}`,
+    message: `Valid issues: #${issues.valid.join(", #")} in ${input.repo}`,
     reason: "valid",
     input,
     issues,
@@ -74,7 +74,13 @@ export function createInvalidResult(
   }
 
   if (issues.wrongState.length > 0) {
-    parts.push(`Wrong state: #${issues.wrongState.join(", #")}`);
+    // Build detailed wrong state message
+    const wrongStateMessages = issues.wrongState.map((issue) => {
+      const expected =
+        input.issueStatus === "all" ? "" : ` (expected: ${input.issueStatus})`;
+      return `#${issue.number} is ${issue.actualState}${expected}`;
+    });
+    parts.push(`Wrong state: ${wrongStateMessages.join(", ")}`);
   }
 
   const message = `${parts.join("; ")} in ${input.repo}`;

--- a/packages/core/src/domain/result-factory.ts
+++ b/packages/core/src/domain/result-factory.ts
@@ -10,10 +10,16 @@ import type {
 /**
  * Create a result for when text is excluded from validation
  */
-export function createExcludedResult(input: InputConfig): CheckMessageResult {
+export function createExcludedResult(
+  input: InputConfig,
+  excludePattern?: string,
+): CheckMessageResult {
+  const message = excludePattern
+    ? `Skipped: Matched exclude pattern "${excludePattern}"`
+    : "Skipped: Matched exclude pattern";
   return {
     success: true,
-    message: "Text was excluded from validation",
+    message,
     reason: "excluded",
     input,
   };
@@ -22,10 +28,16 @@ export function createExcludedResult(input: InputConfig): CheckMessageResult {
 /**
  * Create a result for when validation is skipped due to skip marker
  */
-export function createSkippedResult(input: InputConfig): CheckMessageResult {
+export function createSkippedResult(
+  input: InputConfig,
+  skipMarker?: string,
+): CheckMessageResult {
+  const message = skipMarker
+    ? `Skipped: Contains ${skipMarker} marker`
+    : "Skipped: Contains skip marker";
   return {
     success: true,
-    message: "Validation skipped due to skip marker",
+    message,
     reason: "skipped",
     input,
   };

--- a/packages/core/src/domain/result.ts
+++ b/packages/core/src/domain/result.ts
@@ -23,12 +23,18 @@ export interface InputConfig {
   actionMode?: ActionMode;
 }
 
+// Wrong state issue details
+interface WrongStateIssue {
+  number: number;
+  actualState: "open" | "closed";
+}
+
 // Issue information when issues are found
 export interface IssueInfo {
   found: number[]; // All issue numbers found in text
   valid: number[]; // Issues that exist and match status filter
   notFound: number[]; // Issues that don't exist in repository
-  wrongState: number[]; // Issues with wrong state (e.g., closed when open required)
+  wrongState: WrongStateIssue[]; // Issues with wrong state including actual state info
 }
 
 // Error information when validation fails

--- a/packages/core/src/infrastructure/branch-matcher.test.ts
+++ b/packages/core/src/infrastructure/branch-matcher.test.ts
@@ -35,94 +35,137 @@ describe("branch-matcher", () => {
   describe("shouldExclude", () => {
     describe("custom exclude pattern", () => {
       it("should use custom pattern when provided", () => {
-        expect(shouldExclude("test-branch", "default", "test-*")).toBe(true);
-        expect(shouldExclude("prod-branch", "default", "test-*")).toBe(false);
-        expect(shouldExclude("wip/feature", "branch", "{wip/*,tmp/*}")).toBe(
+        expect(shouldExclude("test-branch", "default", "test-*").excluded).toBe(
           true,
         );
+        expect(shouldExclude("prod-branch", "default", "test-*").excluded).toBe(
+          false,
+        );
+        expect(
+          shouldExclude("wip/feature", "branch", "{wip/*,tmp/*}").excluded,
+        ).toBe(true);
       });
 
       it("should override default patterns", () => {
         // Even though "main" would be excluded by default in branch mode,
         // custom pattern takes precedence
-        expect(shouldExclude("main", "branch", "develop")).toBe(false);
-        expect(shouldExclude("develop", "branch", "develop")).toBe(true);
+        expect(shouldExclude("main", "branch", "develop").excluded).toBe(false);
+        expect(shouldExclude("develop", "branch", "develop").excluded).toBe(
+          true,
+        );
+      });
+
+      it("should return the pattern when excluded", () => {
+        const result = shouldExclude("test-branch", "default", "test-*");
+        expect(result.excluded).toBe(true);
+        expect(result.pattern).toBe("test-*");
       });
     });
 
     describe("branch mode defaults", () => {
       it("should exclude default protected branches", () => {
-        expect(shouldExclude("main", "branch")).toBe(true);
-        expect(shouldExclude("master", "branch")).toBe(true);
-        expect(shouldExclude("develop", "branch")).toBe(true);
-        expect(shouldExclude("release/1.0", "branch")).toBe(true);
+        expect(shouldExclude("main", "branch").excluded).toBe(true);
+        expect(shouldExclude("master", "branch").excluded).toBe(true);
+        expect(shouldExclude("develop", "branch").excluded).toBe(true);
+        expect(shouldExclude("release/1.0", "branch").excluded).toBe(true);
       });
 
       it("should exclude bot branches", () => {
-        expect(shouldExclude("renovate/react-18.x", "branch")).toBe(true);
-        expect(
-          shouldExclude("dependabot/npm_and_yarn/webpack-5.91.0", "branch"),
-        ).toBe(true);
-        expect(shouldExclude("release-please--branches--main", "branch")).toBe(
+        expect(shouldExclude("renovate/react-18.x", "branch").excluded).toBe(
           true,
         );
-        expect(shouldExclude("snyk/fix-vulnerability", "branch")).toBe(true);
-        expect(shouldExclude("imgbot/optimize-images", "branch")).toBe(true);
-        expect(shouldExclude("all-contributors/add-user", "branch")).toBe(true);
+        expect(
+          shouldExclude("dependabot/npm_and_yarn/webpack-5.91.0", "branch")
+            .excluded,
+        ).toBe(true);
+        expect(
+          shouldExclude("release-please--branches--main", "branch").excluded,
+        ).toBe(true);
+        expect(shouldExclude("snyk/fix-vulnerability", "branch").excluded).toBe(
+          true,
+        );
+        expect(shouldExclude("imgbot/optimize-images", "branch").excluded).toBe(
+          true,
+        );
+        expect(
+          shouldExclude("all-contributors/add-user", "branch").excluded,
+        ).toBe(true);
       });
 
       it("should not exclude feature branches including hotfix", () => {
-        expect(shouldExclude("feature/123", "branch")).toBe(false);
-        expect(shouldExclude("123-feature", "branch")).toBe(false);
-        expect(shouldExclude("fix/456", "branch")).toBe(false);
-        expect(shouldExclude("hotfix/urgent-123", "branch")).toBe(false);
-        expect(shouldExclude("hotfix/123-security-patch", "branch")).toBe(
+        expect(shouldExclude("feature/123", "branch").excluded).toBe(false);
+        expect(shouldExclude("123-feature", "branch").excluded).toBe(false);
+        expect(shouldExclude("fix/456", "branch").excluded).toBe(false);
+        expect(shouldExclude("hotfix/urgent-123", "branch").excluded).toBe(
           false,
         );
+        expect(
+          shouldExclude("hotfix/123-security-patch", "branch").excluded,
+        ).toBe(false);
       });
     });
 
     describe("commit mode defaults", () => {
       it("should exclude commits with specific prefixes", () => {
-        expect(shouldExclude("Rebase branch", "commit")).toBe(true);
-        expect(shouldExclude("Merge pull request", "commit")).toBe(true);
-        expect(shouldExclude("Revert commit", "commit")).toBe(true);
-        expect(shouldExclude("fixup! previous commit", "commit")).toBe(true);
-        expect(shouldExclude("squash! old commit", "commit")).toBe(true);
+        expect(shouldExclude("Rebase branch", "commit").excluded).toBe(true);
+        expect(shouldExclude("Merge pull request", "commit").excluded).toBe(
+          true,
+        );
+        expect(shouldExclude("Revert commit", "commit").excluded).toBe(true);
+        expect(shouldExclude("fixup! previous commit", "commit").excluded).toBe(
+          true,
+        );
+        expect(shouldExclude("squash! old commit", "commit").excluded).toBe(
+          true,
+        );
       });
 
       it("should exclude automatic generated commits", () => {
         expect(
-          shouldExclude("Applied suggestion from code review", "commit"),
+          shouldExclude("Applied suggestion from code review", "commit")
+            .excluded,
         ).toBe(true);
-        expect(shouldExclude("Apply automatic changes", "commit")).toBe(true);
-        expect(shouldExclude("Automated Change by bot", "commit")).toBe(true);
-        expect(shouldExclude("Update branch from main", "commit")).toBe(true);
-        expect(shouldExclude("Auto-merge pull request", "commit")).toBe(true);
         expect(
-          shouldExclude("(cherry picked from commit abc123)", "commit"),
+          shouldExclude("Apply automatic changes", "commit").excluded,
         ).toBe(true);
-        expect(shouldExclude("Initial commit", "commit")).toBe(true);
-        expect(shouldExclude("Update README.md", "commit")).toBe(true);
-        expect(shouldExclude("Update docs.md", "commit")).toBe(true);
-        expect(shouldExclude("Updated content", "commit")).toBe(true);
+        expect(
+          shouldExclude("Automated Change by bot", "commit").excluded,
+        ).toBe(true);
+        expect(
+          shouldExclude("Update branch from main", "commit").excluded,
+        ).toBe(true);
+        expect(
+          shouldExclude("Auto-merge pull request", "commit").excluded,
+        ).toBe(true);
+        expect(
+          shouldExclude("(cherry picked from commit abc123)", "commit")
+            .excluded,
+        ).toBe(true);
+        expect(shouldExclude("Initial commit", "commit").excluded).toBe(true);
+        expect(shouldExclude("Update README.md", "commit").excluded).toBe(true);
+        expect(shouldExclude("Update docs.md", "commit").excluded).toBe(true);
+        expect(shouldExclude("Updated content", "commit").excluded).toBe(true);
       });
 
       it("should not exclude regular commits", () => {
-        expect(shouldExclude("feat: add feature", "commit")).toBe(false);
-        expect(shouldExclude("fix: resolve bug", "commit")).toBe(false);
-        expect(shouldExclude("Add new feature", "commit")).toBe(false);
-        expect(shouldExclude("Update user authentication", "commit")).toBe(
+        expect(shouldExclude("feat: add feature", "commit").excluded).toBe(
           false,
         );
+        expect(shouldExclude("fix: resolve bug", "commit").excluded).toBe(
+          false,
+        );
+        expect(shouldExclude("Add new feature", "commit").excluded).toBe(false);
+        expect(
+          shouldExclude("Update user authentication", "commit").excluded,
+        ).toBe(false);
       });
     });
 
     describe("default mode", () => {
       it("should not exclude anything by default", () => {
-        expect(shouldExclude("anything", "default")).toBe(false);
-        expect(shouldExclude("main", "default")).toBe(false);
-        expect(shouldExclude("Merge commit", "default")).toBe(false);
+        expect(shouldExclude("anything", "default").excluded).toBe(false);
+        expect(shouldExclude("main", "default").excluded).toBe(false);
+        expect(shouldExclude("Merge commit", "default").excluded).toBe(false);
       });
     });
   });

--- a/packages/core/src/infrastructure/branch-matcher.ts
+++ b/packages/core/src/infrastructure/branch-matcher.ts
@@ -25,22 +25,23 @@ export function isBranchExcluded(branch: string, pattern: string): boolean {
  * @param text - The text to check
  * @param checkMode - The check mode
  * @param customExclude - Optional custom exclude pattern
- * @returns true if text should be excluded
+ * @returns Object with exclusion status and the pattern used
  */
 export function shouldExclude(
   text: string,
   checkMode: CheckMode,
   customExclude?: string,
-): boolean {
+): { excluded: boolean; pattern?: string } {
   // Use custom exclude pattern if provided, otherwise use mode-specific default
   const pattern = customExclude ?? EXCLUDE_PATTERNS[checkMode];
 
   // No pattern means no exclusion
   if (!pattern) {
-    return false;
+    return { excluded: false };
   }
 
-  return minimatch(text, pattern);
+  const excluded = minimatch(text, pattern);
+  return excluded ? { excluded, pattern } : { excluded };
 }
 
 /**

--- a/packages/core/src/infrastructure/skip-marker-checker.ts
+++ b/packages/core/src/infrastructure/skip-marker-checker.ts
@@ -10,3 +10,19 @@ import { SKIP_MARKERS } from "../domain/constants.js";
 export function hasSkipMarker(text: string): boolean {
   return SKIP_MARKERS.some((marker) => marker.test(text));
 }
+
+/**
+ * Find which skip marker is present in the text
+ * @param text - Text to check for skip markers
+ * @returns The matched skip marker text or null if not found
+ */
+export function findSkipMarker(text: string): string | null {
+  for (const marker of SKIP_MARKERS) {
+    if (marker.test(text)) {
+      // Get the actual matched string from the text
+      const match = text.match(marker);
+      return match ? match[0] : null;
+    }
+  }
+  return null;
+}

--- a/scripts/testing/e2e-npm-package.ts
+++ b/scripts/testing/e2e-npm-package.ts
@@ -106,7 +106,7 @@ try {
   const output = execSync(
     `"${cliCommand}" -t main --check-mode branch`,
   ).toString();
-  if (!output.includes("excluded from validation")) {
+  if (!output.includes("Skipped: Matched exclude pattern")) {
     throw new Error("Branch validation test failed");
   }
   console.log("  ✅ Branch validation works");


### PR DESCRIPTION
## Summary
Adds automatic release PR update after bun.lock is synchronized in release-please PRs.

## Problem
When the `ci-sync-bun-lock-from-release-pr` workflow adds a commit to sync bun.lock, the CHANGELOG in the release PR doesn't get updated automatically. This means the bun.lock sync commit doesn't appear in the release notes.

## Solution
Added a step to re-run release-please action after bun.lock is synced:
- Added output variable `bun_lock_updated` to track if changes were made
- Conditionally runs `googleapis/release-please-action@v4` when bun.lock is updated
- This ensures the CHANGELOG is regenerated with all commits

## Changes
- Modified `.github/workflows/ci-sync-bun-lock-from-release-pr.yml`
  - Added `id: commit` to the commit step
  - Added `bun_lock_updated` output variable
  - Added new step to update release PR using release-please action

## Test Plan
- [ ] Wait for next release-please PR
- [ ] Verify bun.lock gets synced automatically
- [ ] Confirm release PR is updated with the sync commit

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>