### PR TITLE
fix: remove --frozen-lockfile to resolve release-please compatibility

### DIFF
--- a/.github/workflows/ci-pull-request.yml
+++ b/.github/workflows/ci-pull-request.yml
@@ -27,7 +27,9 @@ jobs:
           bun-version: latest
 
       - name: Install dependencies
-        run: bun install --frozen-lockfile
+        # NOTE: Not using --frozen-lockfile because release-please updates package.json versions
+        # but bun.lock still references old versions, causing installation failures
+        run: bun install
 
       - name: Check code quality
         run: bun run check

--- a/.github/workflows/ci-push-main.yml
+++ b/.github/workflows/ci-push-main.yml
@@ -22,7 +22,9 @@ jobs:
           bun-version: latest
 
       - name: Install dependencies
-        run: bun install --frozen-lockfile
+        # NOTE: Not using --frozen-lockfile because release-please updates package.json versions
+        # but bun.lock still references old versions, causing installation failures
+        run: bun install
 
       - name: Check code quality
         run: bun run check

--- a/.github/workflows/validate-branch-name.yml
+++ b/.github/workflows/validate-branch-name.yml
@@ -24,7 +24,9 @@ jobs:
           bun-version: latest
 
       - name: Install dependencies
-        run: bun install --frozen-lockfile
+        # NOTE: Not using --frozen-lockfile because release-please updates package.json versions
+        # but bun.lock still references old versions, causing installation failures
+        run: bun install
 
       - name: Validate branch name
         run: bun run validate:branch


### PR DESCRIPTION
## Summary

This PR removes `--frozen-lockfile` from all CI workflows to fix E2E test failures in release-please PRs.

## Problem

When release-please creates a PR:
1. It updates package.json versions (e.g., 1.0.1 → 1.1.0)
2. But bun.lock still references the old versions
3. `bun install --frozen-lockfile` fails because of version mismatch
4. E2E tests fail in release-please PRs

## Solution

Remove `--frozen-lockfile` from all workflows and add explanatory comments to prevent reintroduction.

## Changes

- Remove `--frozen-lockfile` from:
  - `ci-pull-request.yml`
  - `ci-push-main.yml`
  - `validate-branch-name.yml`
- Add comments explaining why `--frozen-lockfile` is not used

## Impact

- ✅ Fixes E2E test failures in release-please PRs
- ✅ Simplifies workflow logic
- ✅ No conditional installation logic needed
- ⚠️ Slightly less strict dependency checking (acceptable trade-off)

## Testing

All CI checks should pass, including in release-please PRs.