### PR TITLE
feat: add hyphen variants for skip markers

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -175,7 +175,8 @@
       "Bash(./packages/cli/dist/cli.js -t \"Fix #6\" --issue-status open)",
       "Bash(issue-linker:*)",
       "Bash(git --no-pager log -1 --pretty=%s)",
-      "Bash(do echo \"Checking: $file\")"
+      "Bash(do echo \"Checking: $file\")",
+      "Bash(time:*)"
     ],
     "deny": []
   },

--- a/.github/workflows/ci-npm-released-tasks.yml
+++ b/.github/workflows/ci-npm-released-tasks.yml
@@ -46,12 +46,12 @@ jobs:
       - name: Use published action with skip marker
         uses: sugurutakahashi-1234/issue-linker@main
         with:
-          text: '[skip-issue-linker] Test message #123'
+          text: '[skip issue-linker] Test message #123'
       
       - name: Verify test
         run: |
           echo "✅ GitHub Action marketplace test successful"
-          echo "Note: Action should skip processing due to [skip-issue-linker] marker"
+          echo "Note: Action should skip processing due to [skip issue-linker] marker"
 
   # Update bun.lock and create PR
   update-bun-lock:

--- a/.github/workflows/ci-pull-request.yml
+++ b/.github/workflows/ci-pull-request.yml
@@ -27,9 +27,21 @@ jobs:
           bun-version: latest
 
       - name: Install dependencies
-        # NOTE: Not using --frozen-lockfile because release-please updates package.json versions
-        # but bun.lock still references old versions, causing installation failures
-        run: bun install
+        run: |
+          if [[ "${{ github.event.pull_request.user.login }}" == "github-actions[bot]" ]]; then
+            # Release-please PR: Skip lockfile check
+            bun install
+          else
+            # Regular PR: Verify lockfile is in sync
+            rm -f bun.lock
+            bun install
+            
+            if ! git diff --exit-code bun.lock > /dev/null 2>&1; then
+              echo "❌ bun.lock is out of sync! Please run: rm -f bun.lock && bun install"
+              git diff bun.lock
+              exit 1
+            fi
+          fi
 
       - name: Check code quality
         run: bun run check

--- a/README.md
+++ b/README.md
@@ -127,16 +127,13 @@ issue-linker provides three check modes for different validation contexts:
 
 ## Skip Markers
 
-Skip validation by including `[skip issue-linker]` or `[issue-linker skip]` anywhere in your text (case-insensitive). Works in all check modes.
+Skip validation by including any of these markers anywhere in your text (case-insensitive). Works in all check modes:
+- `[skip issue-linker]` or `[skip-issue-linker]`
+- `[issue-linker skip]` or `[issue-linker-skip]`
 
 ```bash
-# Skip auto-generated PR titles
 issue-linker -t "Release v2.0.0 [skip issue-linker]"
 # > ⏭️ Skipped: Contains [skip issue-linker] marker
-
-# Skip dependency updates
-issue-linker -t "chore: update dependencies [issue-linker skip]" -c commit
-# > ⏭️ Skipped: Contains [issue-linker skip] marker
 ```
 
 ## GitHub Actions

--- a/bun.lock
+++ b/bun.lock
@@ -37,7 +37,7 @@
     },
     "packages/cli": {
       "name": "issue-linker",
-      "version": "1.0.1",
+      "version": "1.1.0",
       "bin": {
         "issue-linker": "dist/cli.js",
       },
@@ -54,7 +54,7 @@
     },
     "packages/core": {
       "name": "@issue-linker/core",
-      "version": "1.0.1",
+      "version": "1.1.0",
       "dependencies": {
         "@octokit/plugin-retry": "^8.0.1",
         "@octokit/plugin-throttling": "^11.0.1",
@@ -153,17 +153,17 @@
 
     "@fastify/busboy": ["@fastify/busboy@2.1.1", "", {}, "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA=="],
 
-    "@inquirer/checkbox": ["@inquirer/checkbox@4.2.0", "", { "dependencies": { "@inquirer/core": "^10.1.15", "@inquirer/figures": "^1.0.13", "@inquirer/type": "^3.0.8", "ansi-escapes": "^4.3.2", "yoctocolors-cjs": "^2.1.2" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-fdSw07FLJEU5vbpOPzXo5c6xmMGDzbZE2+niuDHX5N6mc6V0Ebso/q3xiHra4D73+PMsC8MJmcaZKuAAoaQsSA=="],
+    "@inquirer/checkbox": ["@inquirer/checkbox@4.2.1", "", { "dependencies": { "@inquirer/core": "^10.1.15", "@inquirer/figures": "^1.0.13", "@inquirer/type": "^3.0.8", "ansi-escapes": "^4.3.2", "yoctocolors-cjs": "^2.1.2" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-bevKGO6kX1eM/N+pdh9leS5L7TBF4ICrzi9a+cbWkrxeAeIcwlo/7OfWGCDERdRCI2/Q6tjltX4bt07ALHDwFw=="],
 
     "@inquirer/confirm": ["@inquirer/confirm@5.1.14", "", { "dependencies": { "@inquirer/core": "^10.1.15", "@inquirer/type": "^3.0.8" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-5yR4IBfe0kXe59r1YCTG8WXkUbl7Z35HK87Sw+WUyGD8wNUx7JvY7laahzeytyE1oLn74bQnL7hstctQxisQ8Q=="],
 
     "@inquirer/core": ["@inquirer/core@10.1.15", "", { "dependencies": { "@inquirer/figures": "^1.0.13", "@inquirer/type": "^3.0.8", "ansi-escapes": "^4.3.2", "cli-width": "^4.1.0", "mute-stream": "^2.0.0", "signal-exit": "^4.1.0", "wrap-ansi": "^6.2.0", "yoctocolors-cjs": "^2.1.2" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-8xrp836RZvKkpNbVvgWUlxjT4CraKk2q+I3Ksy+seI2zkcE+y6wNs1BVhgcv8VyImFecUhdQrYLdW32pAjwBdA=="],
 
-    "@inquirer/editor": ["@inquirer/editor@4.2.16", "", { "dependencies": { "@inquirer/core": "^10.1.15", "@inquirer/external-editor": "^1.0.0", "@inquirer/type": "^3.0.8" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-iSzLjT4C6YKp2DU0fr8T7a97FnRRxMO6CushJnW5ktxLNM2iNeuyUuUA5255eOLPORoGYCrVnuDOEBdGkHGkpw=="],
+    "@inquirer/editor": ["@inquirer/editor@4.2.17", "", { "dependencies": { "@inquirer/core": "^10.1.15", "@inquirer/external-editor": "^1.0.1", "@inquirer/type": "^3.0.8" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-r6bQLsyPSzbWrZZ9ufoWL+CztkSatnJ6uSxqd6N+o41EZC51sQeWOzI6s5jLb+xxTWxl7PlUppqm8/sow241gg=="],
 
     "@inquirer/expand": ["@inquirer/expand@4.0.17", "", { "dependencies": { "@inquirer/core": "^10.1.15", "@inquirer/type": "^3.0.8", "yoctocolors-cjs": "^2.1.2" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-PSqy9VmJx/VbE3CT453yOfNa+PykpKg/0SYP7odez1/NWBGuDXgPhp4AeGYYKjhLn5lUUavVS/JbeYMPdH50Mw=="],
 
-    "@inquirer/external-editor": ["@inquirer/external-editor@1.0.0", "", { "dependencies": { "chardet": "^2.1.0", "iconv-lite": "^0.6.3" }, "peerDependencies": { "@types/node": ">=18" } }, "sha512-5v3YXc5ZMfL6OJqXPrX9csb4l7NlQA2doO1yynUjpUChT9hg4JcuBVP0RbsEJ/3SL/sxWEyFjT2W69ZhtoBWqg=="],
+    "@inquirer/external-editor": ["@inquirer/external-editor@1.0.1", "", { "dependencies": { "chardet": "^2.1.0", "iconv-lite": "^0.6.3" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-Oau4yL24d2B5IL4ma4UpbQigkVhzPDXLoqy1ggK4gnHg/stmkffJE4oOXHXF3uz0UEpywG68KcyXsyYpA1Re/Q=="],
 
     "@inquirer/figures": ["@inquirer/figures@1.0.13", "", {}, "sha512-lGPVU3yO9ZNqA7vTYz26jny41lE7yoQansmqdMLBEfqaGsmdg7V3W9mK9Pvb5IL4EVZ9GnSDGMO/cJXud5dMaw=="],
 
@@ -173,7 +173,7 @@
 
     "@inquirer/password": ["@inquirer/password@4.0.17", "", { "dependencies": { "@inquirer/core": "^10.1.15", "@inquirer/type": "^3.0.8", "ansi-escapes": "^4.3.2" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-DJolTnNeZ00E1+1TW+8614F7rOJJCM4y4BAGQ3Gq6kQIG+OJ4zr3GLjIjVVJCbKsk2jmkmv6v2kQuN/vriHdZA=="],
 
-    "@inquirer/prompts": ["@inquirer/prompts@7.8.1", "", { "dependencies": { "@inquirer/checkbox": "^4.2.0", "@inquirer/confirm": "^5.1.14", "@inquirer/editor": "^4.2.16", "@inquirer/expand": "^4.0.17", "@inquirer/input": "^4.2.1", "@inquirer/number": "^3.0.17", "@inquirer/password": "^4.0.17", "@inquirer/rawlist": "^4.1.5", "@inquirer/search": "^3.1.0", "@inquirer/select": "^4.3.1" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-LpBPeIpyCF1H3C7SK/QxJQG4iV1/SRmJdymfcul8PuwtVhD0JI1CSwqmd83VgRgt1QEsDojQYFSXJSgo81PVMw=="],
+    "@inquirer/prompts": ["@inquirer/prompts@7.8.2", "", { "dependencies": { "@inquirer/checkbox": "^4.2.1", "@inquirer/confirm": "^5.1.14", "@inquirer/editor": "^4.2.17", "@inquirer/expand": "^4.0.17", "@inquirer/input": "^4.2.1", "@inquirer/number": "^3.0.17", "@inquirer/password": "^4.0.17", "@inquirer/rawlist": "^4.1.5", "@inquirer/search": "^3.1.0", "@inquirer/select": "^4.3.1" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-nqhDw2ZcAUrKNPwhjinJny903bRhI0rQhiDz1LksjeRxqa36i3l75+4iXbOy0rlDpLJGxqtgoPavQjmmyS5UJw=="],
 
     "@inquirer/rawlist": ["@inquirer/rawlist@4.1.5", "", { "dependencies": { "@inquirer/core": "^10.1.15", "@inquirer/type": "^3.0.8", "yoctocolors-cjs": "^2.1.2" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-R5qMyGJqtDdi4Ht521iAkNqyB6p2UPuZUbMifakg1sWtu24gc2Z8CJuw8rP081OckNDMgtDCuLe42Q2Kr3BolA=="],
 
@@ -435,7 +435,7 @@
 
     "ini": ["ini@4.1.1", "", {}, "sha512-QQnnxNyfvmHFIsj7gkPcYymR8Jdw/o7mp5ZFihxn6h8Ci6fh3Dx4E1gPjpQEpIuPo9XVNY/ZUwh4BPMjGyL01g=="],
 
-    "inquirer": ["inquirer@12.9.1", "", { "dependencies": { "@inquirer/core": "^10.1.15", "@inquirer/prompts": "^7.8.1", "@inquirer/type": "^3.0.8", "ansi-escapes": "^4.3.2", "mute-stream": "^2.0.0", "run-async": "^4.0.5", "rxjs": "^7.8.2" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-G7uXAb9OiLcd+9jmA/7KKrItvFF00kKk/jb6CtG+Tm2zSPWfzzhyJwDhVCy+mBmE32o2zJnB5JnknIIv2Ft+AA=="],
+    "inquirer": ["inquirer@12.9.2", "", { "dependencies": { "@inquirer/core": "^10.1.15", "@inquirer/prompts": "^7.8.2", "@inquirer/type": "^3.0.8", "ansi-escapes": "^4.3.2", "mute-stream": "^2.0.0", "run-async": "^4.0.5", "rxjs": "^7.8.2" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-XPukbomHpZc3GAajQdAcuqa5NCIFhUcLMcXXSpJLM2RW/u/5JHLxjLF206GNTJARib8XBBRqyMbaNrDzXROdoA=="],
 
     "is-arrayish": ["is-arrayish@0.2.1", "", {}, "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg=="],
 

--- a/packages/action/dist/index.js
+++ b/packages/action/dist/index.js
@@ -70689,11 +70689,13 @@ const EXTRACT_PATTERNS = {
 // ===== Skip Markers =====
 /**
  * Skip markers that bypass validation entirely
- * Case-insensitive patterns to match [skip issue-linker] and [issue-linker skip]
+ * Case-insensitive patterns to match skip markers with space or hyphen
  */
 const constants_SKIP_MARKERS = [
     /\[skip issue-linker\]/i,
     /\[issue-linker skip\]/i,
+    /\[skip-issue-linker\]/i,
+    /\[issue-linker-skip\]/i,
 ];
 //# sourceMappingURL=constants.js.map
 ;// CONCATENATED MODULE: ../core/dist/infrastructure/branch-matcher.js

--- a/packages/core/src/domain/constants.ts
+++ b/packages/core/src/domain/constants.ts
@@ -31,9 +31,11 @@ export const EXTRACT_PATTERNS: Record<CheckMode, RegExp> = {
 
 /**
  * Skip markers that bypass validation entirely
- * Case-insensitive patterns to match [skip issue-linker] and [issue-linker skip]
+ * Case-insensitive patterns to match skip markers with space or hyphen
  */
 export const SKIP_MARKERS = [
   /\[skip issue-linker\]/i,
   /\[issue-linker skip\]/i,
+  /\[skip-issue-linker\]/i,
+  /\[issue-linker-skip\]/i,
 ] as const;

--- a/packages/core/src/infrastructure/skip-marker-checker.test.ts
+++ b/packages/core/src/infrastructure/skip-marker-checker.test.ts
@@ -20,6 +20,22 @@ describe("hasSkipMarker", () => {
       );
       expect(hasSkipMarker("Text at end [issue-linker skip]")).toBe(true);
     });
+
+    it("should detect [skip-issue-linker]", () => {
+      expect(hasSkipMarker("[skip-issue-linker] Some text")).toBe(true);
+      expect(hasSkipMarker("Text with [skip-issue-linker] in middle")).toBe(
+        true,
+      );
+      expect(hasSkipMarker("Text at end [skip-issue-linker]")).toBe(true);
+    });
+
+    it("should detect [issue-linker-skip]", () => {
+      expect(hasSkipMarker("[issue-linker-skip] Some text")).toBe(true);
+      expect(hasSkipMarker("Text with [issue-linker-skip] in middle")).toBe(
+        true,
+      );
+      expect(hasSkipMarker("Text at end [issue-linker-skip]")).toBe(true);
+    });
   });
 
   describe("case insensitivity", () => {
@@ -31,6 +47,12 @@ describe("hasSkipMarker", () => {
         "[ISSUE-LINKER SKIP]",
         "[Issue-Linker Skip]",
         "[issue-linker SKIP]",
+        "[SKIP-ISSUE-LINKER]",
+        "[Skip-Issue-Linker]",
+        "[skip-ISSUE-linker]",
+        "[ISSUE-LINKER-SKIP]",
+        "[Issue-Linker-Skip]",
+        "[issue-linker-SKIP]",
       ];
 
       for (const text of testCases) {
@@ -43,7 +65,6 @@ describe("hasSkipMarker", () => {
     it("should not detect invalid markers", () => {
       const testCases = [
         "skip issue-linker", // Missing brackets
-        "[skip-issue-linker]", // Hyphen instead of space
         "[skip issuelinker]", // Missing hyphen
         "[skip issue linker]", // Missing hyphen between issue and linker
         "[skipissue-linker]", // No space after skip


### PR DESCRIPTION
## Summary
- Add support for hyphen variants of skip markers: `[skip-issue-linker]` and `[issue-linker-skip]`
- Update tests to cover new skip marker variants
- Update README documentation to list all supported formats

## Test plan
- [x] Unit tests added for new skip markers
- [x] CI tests pass successfully
- [x] README documentation updated

🤖 Generated with [Claude Code](https://claude.ai/code)